### PR TITLE
Add compiler/linking flag for Linux

### DIFF
--- a/squirrel/sq_vm.go
+++ b/squirrel/sq_vm.go
@@ -4,7 +4,7 @@ package squirrel
 #cgo CXXFLAGS: -ISQUIRREL3/include -ISQUIRREL3
 #cgo CPPFLAGS: -ISQUIRREL3/include -ISQUIRREL3
 #cgo CFLAGS: -ISQUIRREL3/include -ISQUIRREL3
-#cgo LDFLAGS: -Lsquirrel/SQUIRREL3/lib -lsquirrel -lsqstdlib -lstdc++ -static-libstdc++
+#cgo LDFLAGS: -Lsquirrel/SQUIRREL3/lib -lsquirrel -lsqstdlib -lstdc++ -static-libstdc++ -lm
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I was unable to build on Debian.  Used to have the same problem on Arch linux but this time figured out the fix.  Not tested in any other environments.
